### PR TITLE
Management/jacoco

### DIFF
--- a/.infra/build.sh
+++ b/.infra/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-mvn clean install -PlocalCheck

--- a/.infra/mvn_sonar.sh
+++ b/.infra/mvn_sonar.sh
@@ -2,8 +2,8 @@
 
 if [[ $TRAVIS_BRANCH == 'master' ]]
 then
-    mvn clean verify sonar:sonar -P noCoverage -Dsonar.projectKey=com.github.cloudyrock.dimmer -Dsonar.organization=cloudyrock -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=b3ad74729ae5d41a7248e50e686d44b755f3a092
+    mvn clean verify sonar:sonar -Dsonar.projectKey=com.github.cloudyrock.dimmer -Dsonar.organization=cloudyrock -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=b3ad74729ae5d41a7248e50e686d44b755f3a092
 else
-    mvn clean verify sonar:sonar -P noCoverage -Dsonar.projectKey=com.github.cloudyrock.dimmer -Dsonar.organization=cloudyrock -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=b3ad74729ae5d41a7248e50e686d44b755f3a092 -Dsonar.pullrequest.base=master -Dsonar.pullrequest.key=$TRAVIS_PULL_REQUEST -Dsonar.pullrequest.branch=$TRAVIS_PULL_REQUEST_BRANCH
+    mvn clean verify sonar:sonar -Dsonar.projectKey=com.github.cloudyrock.dimmer -Dsonar.organization=cloudyrock -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=b3ad74729ae5d41a7248e50e686d44b755f3a092 -Dsonar.pullrequest.base=master -Dsonar.pullrequest.key=$TRAVIS_PULL_REQUEST -Dsonar.pullrequest.branch=$TRAVIS_PULL_REQUEST_BRANCH
 fi
 

--- a/.infra/mvn_sonar.sh
+++ b/.infra/mvn_sonar.sh
@@ -2,8 +2,8 @@
 
 if [[ $TRAVIS_BRANCH == 'master' ]]
 then
-    mvn clean verify sonar:sonar -Dsonar.projectKey=com.github.cloudyrock.dimmer -Dsonar.organization=cloudyrock -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=b3ad74729ae5d41a7248e50e686d44b755f3a092
+    mvn clean verify sonar:sonar -P noCoverage -Dsonar.projectKey=com.github.cloudyrock.dimmer -Dsonar.organization=cloudyrock -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=b3ad74729ae5d41a7248e50e686d44b755f3a092
 else
-    mvn clean verify sonar:sonar -Dsonar.projectKey=com.github.cloudyrock.dimmer -Dsonar.organization=cloudyrock -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=b3ad74729ae5d41a7248e50e686d44b755f3a092 -Dsonar.pullrequest.base=master -Dsonar.pullrequest.key=$TRAVIS_PULL_REQUEST -Dsonar.pullrequest.branch=$TRAVIS_PULL_REQUEST_BRANCH
+    mvn clean verify sonar:sonar -P noCoverage -Dsonar.projectKey=com.github.cloudyrock.dimmer -Dsonar.organization=cloudyrock -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=b3ad74729ae5d41a7248e50e686d44b755f3a092 -Dsonar.pullrequest.base=master -Dsonar.pullrequest.key=$TRAVIS_PULL_REQUEST -Dsonar.pullrequest.branch=$TRAVIS_PULL_REQUEST_BRANCH
 fi
 

--- a/dimmer-core/pom.xml
+++ b/dimmer-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.cloudyrock.dimmer</groupId>
         <artifactId>dimmer-parent</artifactId>
-        <version>2.2.2</version>
+        <version>2.2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>dimmer-core</artifactId>

--- a/dimmer-core/pom.xml
+++ b/dimmer-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.cloudyrock.dimmer</groupId>
         <artifactId>dimmer-parent</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>dimmer-core</artifactId>

--- a/dimmer-core/pom.xml
+++ b/dimmer-core/pom.xml
@@ -31,8 +31,8 @@
         <jacoco.version>0.7.7.201606060606</jacoco.version>
         <jacoco.out.ut.file>jacoco.exec</jacoco.out.ut.file>
         <jacoco.out.it.file>jacoco-it.exec</jacoco.out.it.file>
-        <sonar.jacoco.reportPath>${jacoco.outputDir}/${jacoco.out.ut.file}</sonar.jacoco.reportPath>
-        <sonar.jacoco.itReportPath>${jacoco.outputDir}/${jacoco.out.it.file}</sonar.jacoco.itReportPath>
+        <sonar.jacoco.unitReportPath>${jacoco.outputDir}/${jacoco.out.ut.file}</sonar.jacoco.unitReportPath>
+        <sonar.jacoco.integrationReportPath>${jacoco.outputDir}/${jacoco.out.it.file}</sonar.jacoco.integrationReportPath>
 
     </properties>
 
@@ -77,39 +77,85 @@
 
 
     <profiles>
+
         <profile>
-            <id>localCheck</id>
+            <id>noCoverage</id>
+        </profile>
+
+        <profile>
+            <id>withCoverage</id>
+            <activation><activeByDefault>true</activeByDefault></activation>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <version>${jacoco.version}</version>
-                        <configuration>
-                            <excludes>
-                            </excludes>
-                        </configuration>
                         <executions>
+                            <!-- Prepare agent for unit test -->
                             <execution>
-                                <id>prepare-jacoco-${project.name}</id>
+                                <id>jacoco-ut-prepare-agent(${project.name})</id>
+                                <phase>process-test-classes</phase>
                                 <goals>
                                     <goal>prepare-agent</goal>
-                                    <goal>prepare-agent-integration</goal>
                                 </goals>
+                                <configuration>
+                                    <destFile>${sonar.jacoco.unitReportPath}</destFile>
+                                    <propertyName>jacoco.agent.ut.arg</propertyName>
+                                    <append>true</append>
+                                </configuration>
                             </execution>
+
+                            <!-- Produce report for unit test -->
                             <execution>
-                                <id>report-jacoco-${project.name}</id>
-                                <phase>prepare-package</phase>
+                                <id>jacoco-ut-report(${project.name})</id>
+                                <phase>test</phase>
                                 <goals>
                                     <goal>report</goal>
                                 </goals>
+                                <configuration>
+                                    <dataFile>${sonar.jacoco.unitReportPath}</dataFile>
+                                    <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
+                                </configuration>
                             </execution>
+
+
+                            <!-- Prepare agent for integration test -->
                             <execution>
-                                <id>jacoco-check-${project.name}</id>
+                                <id>jacoco-it-prepare-agent(${project.name})</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <destFile>${sonar.jacoco.integrationReportPath}</destFile>
+                                    <propertyName>jacoco.agent.it.arg</propertyName>
+                                    <append>true</append>
+                                </configuration>
+                            </execution>
+
+                            <!-- Produce report for integration test -->
+                            <execution>
+                                <id>jacoco-it-report(${project.name})</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <dataFile>${sonar.jacoco.integrationReportPath}</dataFile>
+                                    <outputDirectory>${project.reporting.outputDirectory}/jacoco-it</outputDirectory>
+                                </configuration>
+                            </execution>
+
+                            <!-- Perform coverage verification for unit test -->
+                            <execution>
+                                <id>jacoco-ut-verify-coverage(${project.name})</id>
                                 <goals>
                                     <goal>check</goal>
                                 </goals>
                                 <configuration>
+
+                                    <dataFile>${sonar.jacoco.unitReportPath}</dataFile>
                                     <rules>
                                         <rule>
                                             <element>PACKAGE</element>
@@ -117,59 +163,38 @@
                                                 <limit>
                                                     <counter>LINE</counter>
                                                     <value>COVEREDRATIO</value>
-                                                    <minimum>${threshold.coverage}</minimum>
+                                                    <minimum>${threshold.coverage.ut}</minimum>
                                                 </limit>
                                             </limits>
                                         </rule>
                                     </rules>
                                 </configuration>
                             </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
 
-        <profile>
-            <id>sonarqube</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>${jacoco.version}</version>
-                        <executions>
+                            <!-- Perform coverage verification for integration test -->
                             <execution>
-                                <id>prepare-ut-agent</id>
-                                <phase>process-test-classes</phase>
+                                <id>jacoco-it-verify-coverage(${project.name})</id>
                                 <goals>
-                                    <goal>prepare-agent</goal>
+                                    <goal>check</goal>
                                 </goals>
                                 <configuration>
-                                    <destFile>${sonar.jacoco.reportPath}</destFile>
-                                    <propertyName>jacoco.agent.ut.arg</propertyName>
-                                    <append>true</append>
+
+                                    <dataFile>${sonar.jacoco.integrationReportPath}</dataFile>
+                                    <rules>
+                                        <rule>
+                                            <element>PACKAGE</element>
+                                            <limits>
+                                                <limit>
+                                                    <counter>LINE</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>${threshold.coverage.it}</minimum>
+                                                </limit>
+                                            </limits>
+                                        </rule>
+                                    </rules>
                                 </configuration>
                             </execution>
-                            <execution>
-                                <id>prepare-it-agent</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>prepare-agent-integration</goal>
-                                </goals>
-                                <configuration>
-                                    <destFile>${sonar.jacoco.itReportPath}</destFile>
-                                    <propertyName>jacoco.agent.it.arg</propertyName>
-                                    <append>true</append>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>report-aggregate</id>
-                                <phase>prepare-package</phase>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                            </execution>
+
                         </executions>
                     </plugin>
                 </plugins>

--- a/dimmer-core/pom.xml
+++ b/dimmer-core/pom.xml
@@ -26,13 +26,9 @@
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 
-
-        <!--<jacoco.outputDir>${project.build.directory}/jacoco</jacoco.outputDir>-->
         <jacoco.version>0.7.7.201606060606</jacoco.version>
-        <jacoco.out.ut.file>jacoco.exec</jacoco.out.ut.file>
-        <jacoco.out.it.file>jacoco-it.exec</jacoco.out.it.file>
-        <sonar.jacoco.unitReportPath>${jacoco.outputDir}/${jacoco.out.ut.file}</sonar.jacoco.unitReportPath>
-        <sonar.jacoco.integrationReportPath>${jacoco.outputDir}/${jacoco.out.it.file}</sonar.jacoco.integrationReportPath>
+        <sonar.jacoco.unitReportPath>${jacoco.outputDir}/jacoco-ut.exec</sonar.jacoco.unitReportPath>
+        <sonar.jacoco.integrationReportPath>${jacoco.outputDir}/jacoco-it.exec</sonar.jacoco.integrationReportPath>
 
     </properties>
 

--- a/dimmer-local/pom.xml
+++ b/dimmer-local/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.cloudyrock.dimmer</groupId>
         <artifactId>dimmer-parent</artifactId>
-        <version>2.2.2</version>
+        <version>2.2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>dimmer-local</artifactId>

--- a/dimmer-local/pom.xml
+++ b/dimmer-local/pom.xml
@@ -28,8 +28,8 @@
         <jacoco.version>0.7.7.201606060606</jacoco.version>
         <jacoco.out.ut.file>jacoco.exec</jacoco.out.ut.file>
         <jacoco.out.it.file>jacoco-it.exec</jacoco.out.it.file>
-        <sonar.jacoco.reportPath>${jacoco.outputDir}/${jacoco.out.ut.file}</sonar.jacoco.reportPath>
-        <sonar.jacoco.itReportPath>${jacoco.outputDir}/${jacoco.out.it.file}</sonar.jacoco.itReportPath>
+        <sonar.jacoco.unitReportPath>${jacoco.outputDir}/${jacoco.out.ut.file}</sonar.jacoco.unitReportPath>
+        <sonar.jacoco.integrationReportPath>${jacoco.outputDir}/${jacoco.out.it.file}</sonar.jacoco.integrationReportPath>
 
     </properties>
 
@@ -108,40 +108,87 @@
     </build>
 
 
+
     <profiles>
+
         <profile>
-            <id>localCheck</id>
+            <id>noCoverage</id>
+        </profile>
+
+        <profile>
+            <id>withCoverage</id>
+            <activation><activeByDefault>true</activeByDefault></activation>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <version>${jacoco.version}</version>
-                        <configuration>
-                            <excludes>
-                            </excludes>
-                        </configuration>
                         <executions>
+                            <!-- Prepare agent for unit test -->
                             <execution>
-                                <id>prepare-jacoco-${project.name}</id>
+                                <id>jacoco-ut-prepare-agent(${project.name})</id>
+                                <phase>process-test-classes</phase>
                                 <goals>
                                     <goal>prepare-agent</goal>
-                                    <goal>prepare-agent-integration</goal>
                                 </goals>
+                                <configuration>
+                                    <destFile>${sonar.jacoco.unitReportPath}</destFile>
+                                    <propertyName>jacoco.agent.ut.arg</propertyName>
+                                    <append>true</append>
+                                </configuration>
                             </execution>
+
+                            <!-- Produce report for unit test -->
                             <execution>
-                                <id>report-jacoco-${project.name}</id>
-                                <phase>prepare-package</phase>
+                                <id>jacoco-ut-report(${project.name})</id>
+                                <phase>test</phase>
                                 <goals>
                                     <goal>report</goal>
                                 </goals>
+                                <configuration>
+                                    <dataFile>${sonar.jacoco.unitReportPath}</dataFile>
+                                    <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
+                                </configuration>
                             </execution>
+
+
+                            <!-- Prepare agent for integration test -->
                             <execution>
-                                <id>jacoco-check-${project.name}</id>
+                                <id>jacoco-it-prepare-agent(${project.name})</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <destFile>${sonar.jacoco.integrationReportPath}</destFile>
+                                    <propertyName>jacoco.agent.it.arg</propertyName>
+                                    <append>true</append>
+                                </configuration>
+                            </execution>
+
+                            <!-- Produce report for integration test -->
+                            <execution>
+                                <id>jacoco-it-report(${project.name})</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <dataFile>${sonar.jacoco.integrationReportPath}</dataFile>
+                                    <outputDirectory>${project.reporting.outputDirectory}/jacoco-it</outputDirectory>
+                                </configuration>
+                            </execution>
+
+                            <!-- Perform coverage verification for unit test -->
+                            <execution>
+                                <id>jacoco-ut-verify-coverage(${project.name})</id>
                                 <goals>
                                     <goal>check</goal>
                                 </goals>
                                 <configuration>
+
+                                    <dataFile>${sonar.jacoco.unitReportPath}</dataFile>
                                     <rules>
                                         <rule>
                                             <element>PACKAGE</element>
@@ -149,59 +196,38 @@
                                                 <limit>
                                                     <counter>LINE</counter>
                                                     <value>COVEREDRATIO</value>
-                                                    <minimum>${threshold.coverage}</minimum>
+                                                    <minimum>${threshold.coverage.ut}</minimum>
                                                 </limit>
                                             </limits>
                                         </rule>
                                     </rules>
                                 </configuration>
                             </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
 
-        <profile>
-            <id>sonarqube</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>${jacoco.version}</version>
-                        <executions>
+                            <!-- Perform coverage verification for integration test -->
                             <execution>
-                                <id>prepare-ut-agent</id>
-                                <phase>process-test-classes</phase>
+                                <id>jacoco-it-verify-coverage(${project.name})</id>
                                 <goals>
-                                    <goal>prepare-agent</goal>
+                                    <goal>check</goal>
                                 </goals>
                                 <configuration>
-                                    <destFile>${sonar.jacoco.reportPath}</destFile>
-                                    <propertyName>jacoco.agent.ut.arg</propertyName>
-                                    <append>true</append>
+
+                                    <dataFile>${sonar.jacoco.integrationReportPath}</dataFile>
+                                    <rules>
+                                        <rule>
+                                            <element>PACKAGE</element>
+                                            <limits>
+                                                <limit>
+                                                    <counter>LINE</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>${threshold.coverage.it}</minimum>
+                                                </limit>
+                                            </limits>
+                                        </rule>
+                                    </rules>
                                 </configuration>
                             </execution>
-                            <execution>
-                                <id>prepare-it-agent</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>prepare-agent-integration</goal>
-                                </goals>
-                                <configuration>
-                                    <destFile>${sonar.jacoco.itReportPath}</destFile>
-                                    <propertyName>jacoco.agent.it.arg</propertyName>
-                                    <append>true</append>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>report-aggregate</id>
-                                <phase>prepare-package</phase>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                            </execution>
+
                         </executions>
                     </plugin>
                 </plugins>
@@ -209,5 +235,6 @@
         </profile>
 
     </profiles>
+
 
 </project>

--- a/dimmer-local/pom.xml
+++ b/dimmer-local/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.github.cloudyrock.dimmer</groupId>
         <artifactId>dimmer-parent</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>dimmer-local</artifactId>

--- a/dimmer-local/pom.xml
+++ b/dimmer-local/pom.xml
@@ -26,10 +26,8 @@
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 
         <jacoco.version>0.7.7.201606060606</jacoco.version>
-        <jacoco.out.ut.file>jacoco.exec</jacoco.out.ut.file>
-        <jacoco.out.it.file>jacoco-it.exec</jacoco.out.it.file>
-        <sonar.jacoco.unitReportPath>${jacoco.outputDir}/${jacoco.out.ut.file}</sonar.jacoco.unitReportPath>
-        <sonar.jacoco.integrationReportPath>${jacoco.outputDir}/${jacoco.out.it.file}</sonar.jacoco.integrationReportPath>
+        <sonar.jacoco.unitReportPath>${jacoco.outputDir}/jacoco-ut.exec</sonar.jacoco.unitReportPath>
+        <sonar.jacoco.integrationReportPath>${jacoco.outputDir}/jacoco-it.exec</sonar.jacoco.integrationReportPath>
 
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.cloudyrock.dimmer</groupId>
     <artifactId>dimmer-parent</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.2.2</version>
     <packaging>pom</packaging>
     <name>parent</name>
     <!-- Web site not created yet -->
@@ -39,7 +39,7 @@
         <connection>scm:git:git@github.com:cloudyrock/dimmer.git</connection>
         <developerConnection>scm:git:git@github.com:cloudyrock/dimmer.git</developerConnection>
         <url>https://github.com/cloudyrock/dimmer.git</url>
-        <tag>dimmer-1.4.5</tag>
+        <tag>dimmer-parent-2.2.2</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
 
     <properties>
         <jacoco.outputDir>../target/jacoco</jacoco.outputDir>
-        <threshold.coverage.ut>0.80</threshold.coverage.ut>
-        <threshold.coverage.it>0.80</threshold.coverage.it>
+        <threshold.coverage.ut>0.58</threshold.coverage.ut>
+        <threshold.coverage.it>0.28</threshold.coverage.it>
     </properties>
 
 
@@ -153,6 +153,7 @@
 
         <profile>
             <id>withCoverage</id>
+            <activation><activeByDefault>true</activeByDefault></activation>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.cloudyrock.dimmer</groupId>
     <artifactId>dimmer-parent</artifactId>
-    <version>2.2.2</version>
+    <version>2.2.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>parent</name>
     <!-- Web site not created yet -->
@@ -39,7 +39,7 @@
         <connection>scm:git:git@github.com:cloudyrock/dimmer.git</connection>
         <developerConnection>scm:git:git@github.com:cloudyrock/dimmer.git</developerConnection>
         <url>https://github.com/cloudyrock/dimmer.git</url>
-        <tag>dimmer-parent-2.2.2</tag>
+        <tag>dimmer-1.4.5</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,8 @@
 
     <properties>
         <jacoco.outputDir>../target/jacoco</jacoco.outputDir>
-        <threshold.coverage>0.80</threshold.coverage>
+        <threshold.coverage.ut>0.80</threshold.coverage.ut>
+        <threshold.coverage.it>0.80</threshold.coverage.it>
     </properties>
 
 
@@ -146,12 +147,12 @@
     <profiles>
         <!-- Local check for pull requests -->
         <profile>
-            <id>localCheck</id>
+            <id>noCoverage</id>
         </profile>
 
 
         <profile>
-            <id>sonarqube</id>
+            <id>withCoverage</id>
             <build>
                 <plugins>
                     <plugin>
@@ -178,6 +179,9 @@
                             <includes>
                                 <include>**/*ITest*</include>
                             </includes>
+                            <excludes>
+                                <exclude>**/*UTest*</exclude>
+                            </excludes>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
This change provide 2 profiles:

- **withCoverage(default):** It runs jacoco for integration tests(*ITest.java) and unit tests(*UTest.java).
Provides default and html report, as well as perform coverage test, for both, unit and integrations tests.
The default report(*.exec) it's generated in the parent project for sonar to pick up. The html reports are generated inside each submodule.
To run it just run `mvn clean verify`, it's the default profile

- **noCoverage:** With this profile you can run maven without jacoco.
`mvn clean install -P noCoverage`

